### PR TITLE
1.2.6 agent required for current OMD stable (1.30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 System Monitor Agent
 ====================
 
-Install agents so a system can be externally monitored.
+NOTE: UoD/SLS SpaceWalk managed servers only. This role requires access to a particular version of the Check_MK agent, which RHEL 7/ CentOS 7 repositories do not carry. UoD/SLS spacewalk repositories do provide this rpm.
 
-TODO: Currently this also installs and enables xinetd, this could be moved into a separate role.
+Installs Check_MK agent and deps so a system can be externally monitored.
+
+Currently this also installs and enables xinetd, this could be moved into a separate role.
 
 Author Information
 ------------------

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
     name: "{{ item }}"
     state: present
   with_items:
-    - check-mk-agent
+    - check-mk-agent-1.2.6p16
     - xinetd
 
 - name: xinetd | start and enable


### PR DESCRIPTION
Since `   become: yes` is set, yum should hopefully see the repos provided by spacewalk, and therefore be supplied the correct version of the agent.

This won't work against vanilla CentOS 7 though... (Our systems are offered old version of the check_mk clients)